### PR TITLE
(feat) added support for simultaneously using files and env vars

### DIFF
--- a/venomoid.go
+++ b/venomoid.go
@@ -119,7 +119,9 @@ func (c *ConfigBuilder) Build(destStruct interface{}) error {
 				}
 			}
 		}
-	} else if c.AutomaticEnv {
+	}
+
+	if c.AutomaticEnv {
 		viper.AutomaticEnv()
 
 		if c.EnvPrefix != "" {


### PR DESCRIPTION
Currently one has to choose between using the `AutomaticEnv` feature, or configuration files. But sometimes It would be handy to mix them.

For my use case, I would like to inject secrets into a k8s deployment using environment variables, but I would still like to have a plain-text config map for less sensitive values.